### PR TITLE
Drop setuptools_scm in favour of git-props

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -2,3 +2,4 @@ PyYAML >=5.1
 distutils-pytest
 git-props
 pytest >=3.0.0
+setuptools

--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML >=5.1
 distutils-pytest
+git-props
 pytest >=3.0.0
-setuptools_scm

--- a/README.rst
+++ b/README.rst
@@ -34,13 +34,13 @@ External Programs:
 
 Optional library packages:
 
-+ `setuptools_scm`_
++ `git-props`_
 
-  The version number is managed using this package.  All source
-  distributions add a static text file with the version number and
-  fall back using that if `setuptools_scm` is not available.  So this
-  package is only needed to build out of the plain development source
-  tree as cloned from GitHub.
+  This package is used to extract some metadata such as the version
+  number out of git, the version control system.  All releases embed
+  the metadata in the distribution.  So this package is only needed to
+  build out of the plain development source tree as cloned from
+  GitHub, but not to build a release distribution.
 
 + `pytest`_ >= 3.0
 
@@ -73,7 +73,7 @@ permissions and limitations under the License.
 .. _setuptools: https://github.com/pypa/setuptools/
 .. _packaging: https://github.com/pypa/packaging/
 .. _git: https://git-scm.com/
-.. _setuptools_scm: https://github.com/pypa/setuptools_scm/
+.. _git-props: https://github.com/RKrahl/git-props
 .. _pytest: https://pytest.org/
 .. _distutils-pytest: https://github.com/RKrahl/distutils-pytest
 .. _PyYAML: https://github.com/yaml/pyyaml/

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     author_email = "rolf@rotkraut.de",
     license = "Apache-2.0",
     classifiers = [
-        "Development Status :: 1 - Planning",
+        "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,6 @@ setup(
     packages = ["gitprops"],
     package_dir = {"": "src"},
     python_requires = ">=3.6",
-    install_requires = ["packaging"],
+    install_requires = ["setuptools", "packaging"],
     cmdclass = dict(cmdclass, build_py=build_py, sdist=sdist, meta=meta),
 )

--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,15 @@ try:
 except (ImportError, AttributeError):
     cmdclass = dict()
 try:
-    import setuptools_scm
-    version = setuptools_scm.get_version()
+    import gitprops
+    version = str(gitprops.get_version())
+    release = str(gitprops.get_last_release())
 except (ImportError, LookupError):
     try:
-        import _meta
-        version = _meta.version
+        from _meta import version, release
     except ImportError:
         log.warn("warning: cannot determine version number")
-        version = "UNKNOWN"
+        release = version = "UNKNOWN"
 
 docstring = __doc__
 
@@ -113,7 +113,7 @@ setup(
     ],
     project_urls = dict(
         Source="https://github.com/RKrahl/git-props",
-        Download="https://github.com/RKrahl/git-props/releases/latest",
+        Download=("https://github.com/RKrahl/git-props/releases/%s/" % release),
     ),
     packages = ["gitprops"],
     package_dir = {"": "src"},


### PR DESCRIPTION
Use (possibly a previous release of) `git-props` to manage package metadata.  Drop `setuptools_scm`. Close #1.

Furthermore, a few more minor tweaks to the `setup.py` script:
- set development status to Alpha in the trove classifiers,
- set the download link explicitly to the last release rather than 'latest' in the project URLs.