### PR TITLE
Catch FileNotFoundError raised when git is not available in package level functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,13 @@ New features
 
 + `#2`_, `#6`_: Add a command line interface.
 
+Bug fixes and minor changes
+---------------------------
+
++ `#7`_, `#8`_: package level functions :func:`get_version`,
+  :func:`get_last_release` and :func:`get_date` raise
+  :exc:`LookupError` when the git executable is not found.
+
 Internal changes
 ----------------
 
@@ -19,6 +26,8 @@ Internal changes
 .. _#2: https://github.com/RKrahl/git-props/issues/2
 .. _#5: https://github.com/RKrahl/git-props/pull/5
 .. _#6: https://github.com/RKrahl/git-props/pull/6
+.. _#7: https://github.com/RKrahl/git-props/issues/7
+.. _#8: https://github.com/RKrahl/git-props/pull/8
 
 
 0.1 (2023-12-28)

--- a/src/gitprops/__init__.py
+++ b/src/gitprops/__init__.py
@@ -14,7 +14,10 @@ _repo_cache = dict()
 def _get_repo(root):
     root = Path(root).resolve()
     if root not in _repo_cache:
-        _repo_cache[root] = GitRepo(root)
+        try:
+            _repo_cache[root] = GitRepo(root)
+        except FileNotFoundError as exc:
+            raise LookupError() from exc
     return _repo_cache[root]
 
 

--- a/tests/test_02_toplevel_error.py
+++ b/tests/test_02_toplevel_error.py
@@ -1,0 +1,59 @@
+"""Test errors calling toplevel function at package level.
+"""
+
+import subprocess
+import pytest
+from gitprops import get_version, get_last_release, get_date
+
+_orig_subprocess_run = subprocess.run
+
+def git_fail_run(cmd, **kwargs):
+    """A mockup version of subprocess.run that raises FileNotFoundError
+    whenever the first argument in cmd is 'git'.
+    """
+    if cmd[0] == "git":
+        raise FileNotFoundError(2, "No such file or directory: 'git'")
+    else:
+        return _orig_subprocess_run(cmd, **kwargs)
+
+@pytest.mark.xfail(raises=FileNotFoundError, reason="Issue #7")
+def test_nogit_error_get_version(monkeypatch):
+    """Test the error condition that the git executable is not found.
+    """
+    monkeypatch.setattr(subprocess, "run", git_fail_run)
+    with pytest.raises(LookupError):
+        get_version()
+
+@pytest.mark.xfail(raises=FileNotFoundError, reason="Issue #7")
+def test_nogit_error_get_last_release(monkeypatch):
+    """Test the error condition that the git executable is not found.
+    """
+    monkeypatch.setattr(subprocess, "run", git_fail_run)
+    with pytest.raises(LookupError):
+        get_last_release()
+
+@pytest.mark.xfail(raises=FileNotFoundError, reason="Issue #7")
+def test_nogit_error_get_date(monkeypatch):
+    """Test the error condition that the git executable is not found.
+    """
+    monkeypatch.setattr(subprocess, "run", git_fail_run)
+    with pytest.raises(LookupError):
+        get_date()
+
+def test_norepo_error_get_version(monkeypatch):
+    """Test the error condition that there is no git repository.
+    """
+    with pytest.raises(LookupError):
+        get_version(root='/')
+
+def test_norepo_error_get_last_release(monkeypatch):
+    """Test the error condition that there is no git repository.
+    """
+    with pytest.raises(LookupError):
+        get_last_release(root='/')
+
+def test_norepo_error_get_date(monkeypatch):
+    """Test the error condition that there is no git repository.
+    """
+    with pytest.raises(LookupError):
+        get_date(root='/')

--- a/tests/test_02_toplevel_error.py
+++ b/tests/test_02_toplevel_error.py
@@ -16,7 +16,6 @@ def git_fail_run(cmd, **kwargs):
     else:
         return _orig_subprocess_run(cmd, **kwargs)
 
-@pytest.mark.xfail(raises=FileNotFoundError, reason="Issue #7")
 def test_nogit_error_get_version(monkeypatch):
     """Test the error condition that the git executable is not found.
     """
@@ -24,7 +23,6 @@ def test_nogit_error_get_version(monkeypatch):
     with pytest.raises(LookupError):
         get_version()
 
-@pytest.mark.xfail(raises=FileNotFoundError, reason="Issue #7")
 def test_nogit_error_get_last_release(monkeypatch):
     """Test the error condition that the git executable is not found.
     """
@@ -32,7 +30,6 @@ def test_nogit_error_get_last_release(monkeypatch):
     with pytest.raises(LookupError):
         get_last_release()
 
-@pytest.mark.xfail(raises=FileNotFoundError, reason="Issue #7")
 def test_nogit_error_get_date(monkeypatch):
     """Test the error condition that the git executable is not found.
     """


### PR DESCRIPTION
Fix the functions `get_version()`, `get_last_release()` and `get_date()` defined in `__init__.py`, e.g. at package level: catch `FileNotFoundError` that is raised when git is not available and raise a `LookupError` instead. Fix #7.