### PR TITLE
Review build tool chain

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,9 +12,11 @@ Bug fixes and minor changes
 
 + `#12`_, `#13`_: fix severe performance issues on repos with many
   tags.
++ `#14`_: Minor updates in the tool chain.
 
 .. _#12: https://github.com/RKrahl/git-props/issues/12
 .. _#13: https://github.com/RKrahl/git-props/pull/13
+.. _#14: https://github.com/RKrahl/git-props/pull/14
 
 
 .. _changes-0_3_0:

--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -6,8 +6,17 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
-import _meta
+import os
+from pathlib import Path
+import sys
 
+docsrcdir = Path(__file__).resolve().parent
+maindir = docsrcdir.parent.parent
+buildlib = maindir / "build" / "lib"
+sys.path[0] = str(buildlib)
+sys.dont_write_bytecode = True
+
+import gitprops._meta
 
 # -- Project information -----------------------------------------------------
 
@@ -16,7 +25,7 @@ copyright = '2023–2024, Rolf Krahl'
 author = 'Rolf Krahl'
 
 # The full version, including alpha/beta/rc tags
-release = _meta.__version__
+release = gitprops._meta.version
 # The short X.Y version
 version = ".".join(release.split(".")[0:2])
 
@@ -49,7 +58,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -80,6 +89,15 @@ html_theme = 'sphinx_rtd_theme'
 # documentation.
 #
 # html_theme_options = {}
+
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Some minor review of the tool chain to build the package:
- Disable [PEP 625](https://peps.python.org/pep-0625/) enforcing added in [setuptools 69.3.0](https://setuptools.pypa.io/en/stable/history.html#v69-3-0)
- Minor tweaks in `setup.py`
- Fix importing `_meta` in the documentation build configuration
- Update documentation build configuration to adapt to a [recent change in Read the Docs build](https://about.readthedocs.com/blog/2024/07/addons-by-default/)